### PR TITLE
macos: support build on macOS with clang 15.x

### DIFF
--- a/contrib/ports/unix/port/netif/sio.c
+++ b/contrib/ports/unix/port/netif/sio.c
@@ -10,6 +10,7 @@
    are included */
 #if defined(__APPLE__)
 #define _DARWIN_C_SOURCE
+#include <util.h>
 #endif
 
 #include "netif/sio.h"

--- a/src/apps/http/makefsdata/makefsdata.c
+++ b/src/apps/http/makefsdata/makefsdata.c
@@ -77,7 +77,7 @@ static int deflate_level; /* default compression level, can be changed via comma
 #define CHDIR(path)                   SetCurrentDirectoryA(path)
 #define CHDIR_SUCCEEDED(ret)          (ret == TRUE)
 
-#elif __linux__
+#elif __linux__ || __APPLE__
 
 #define GETCWD(path, len)             getcwd(path, len)
 #define GETCWD_SUCCEEDED(ret)         (ret != NULL)

--- a/src/netif/ppp/fsm.c
+++ b/src/netif/ppp/fsm.c
@@ -40,6 +40,8 @@
  * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+
 #include "netif/ppp/ppp_opts.h"
 #if PPP_SUPPORT /* don't build if not configured for use in lwipopts.h */
 

--- a/src/netif/ppp/pppos.c
+++ b/src/netif/ppp/pppos.c
@@ -31,6 +31,8 @@
  *
  */
 
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+
 #include "netif/ppp/ppp_opts.h"
 #if PPP_SUPPORT && PPPOS_SUPPORT /* don't build if not configured for use in lwipopts.h */
 

--- a/src/netif/ppp/vj.c
+++ b/src/netif/ppp/vj.c
@@ -28,6 +28,8 @@
  * for a 16 bit processor.
  */
 
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+
 #include "netif/ppp/ppp_opts.h"
 #if PPP_SUPPORT && VJ_SUPPORT /* don't build if not configured for use in lwipopts.h */
 


### PR DESCRIPTION
Patches to build on macOS.

Using `#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"` to disable the errors building with `waf` is not nice, but the annotation comments don't seem to be respected? The errors only occur with the `waf` build. A standalone cmake build with clang is fine.

<details> 

```bash
$ mkdir build && cd build
$ cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17
-- The C compiler identification is AppleClang 15.0.0.15000100
-- The CXX compiler identification is AppleClang 15.0.0.15000100
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Build type: RelWithDebInfo
-- LWIP_MBEDTLSDIR not set - using default location /Users/rhys/Code/ardupilot/modules/lwip/../mbedtls
-- Found Doxygen: /opt/homebrew/bin/doxygen (found version "1.10.0") found components: doxygen dot 
-- Doxygen build started
-- Configuring done (0.5s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/rhys/Code/ardupilot/modules/lwip/build
$ make           
[  0%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribportunix.dir/__/port/sys_arch.c.o
[  1%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribportunix.dir/__/port/perf.c.o
[  1%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribportunix.dir/__/port/netif/tapif.c.o
[  2%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribportunix.dir/__/port/netif/list.c.o
[  3%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribportunix.dir/__/port/netif/sio.c.o
[  3%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribportunix.dir/__/port/netif/fifo.c.o
[  4%] Linking C static library liblwipcontribportunix.a
[  4%] Built target lwipcontribportunix
[  4%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/init.c.o
[  5%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/def.c.o
[  6%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/dns.c.o
[  6%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/inet_chksum.c.o
[  7%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ip.c.o
[  7%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/mem.c.o
[  8%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/memp.c.o
[  9%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/netif.c.o
[  9%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/pbuf.c.o
[ 10%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/raw.c.o
[ 10%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/stats.c.o
[ 11%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/sys.c.o
[ 12%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/altcp.c.o
[ 12%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/altcp_alloc.c.o
[ 13%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/altcp_tcp.c.o
[ 13%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/tcp.c.o
[ 14%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/tcp_in.c.o
[ 15%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/tcp_out.c.o
[ 15%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/timeouts.c.o
[ 16%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/udp.c.o
[ 16%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv4/acd.c.o
[ 17%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv4/autoip.c.o
[ 18%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv4/dhcp.c.o
[ 18%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv4/etharp.c.o
[ 19%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv4/icmp.c.o
[ 20%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv4/igmp.c.o
[ 20%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv4/ip4_frag.c.o
[ 21%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv4/ip4.c.o
[ 21%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv4/ip4_addr.c.o
[ 22%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv6/dhcp6.c.o
[ 23%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv6/ethip6.c.o
[ 23%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv6/icmp6.c.o
[ 24%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv6/inet6.c.o
[ 24%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv6/ip6.c.o
[ 25%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv6/ip6_addr.c.o
[ 26%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv6/ip6_frag.c.o
[ 26%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv6/mld6.c.o
[ 27%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/core/ipv6/nd6.c.o
[ 27%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/api/api_lib.c.o
[ 28%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/api/api_msg.c.o
[ 29%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/api/err.c.o
[ 29%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/api/if_api.c.o
[ 30%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/api/netbuf.c.o
[ 30%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/api/netdb.c.o
[ 31%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/api/netifapi.c.o
[ 32%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/api/sockets.c.o
[ 32%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/api/tcpip.c.o
[ 33%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ethernet.c.o
[ 33%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/bridgeif.c.o
[ 34%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/bridgeif_fdb.c.o
[ 35%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/lowpan6_common.c.o
[ 35%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/lowpan6.c.o
[ 36%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/lowpan6_ble.c.o
[ 36%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/zepif.c.o
[ 37%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/auth.c.o
[ 38%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/ccp.c.o
[ 38%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/chap-md5.c.o
[ 39%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/chap_ms.c.o
[ 40%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/chap-new.c.o
[ 40%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/demand.c.o
[ 41%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/eap.c.o
[ 41%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/ecp.c.o
[ 42%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/eui64.c.o
[ 43%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/fsm.c.o
[ 43%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/ipcp.c.o
[ 44%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/ipv6cp.c.o
[ 44%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/lcp.c.o
[ 45%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/magic.c.o
[ 46%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/mppe.c.o
[ 46%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/multilink.c.o
[ 47%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/ppp.c.o
[ 47%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/pppapi.c.o
[ 48%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/pppcrypt.c.o
[ 49%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/pppoe.c.o
[ 49%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/pppol2tp.c.o
[ 50%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/pppos.c.o
[ 50%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/upap.c.o
[ 51%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/utils.c.o
[ 52%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/vj.c.o
[ 52%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/polarssl/arc4.c.o
[ 53%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/polarssl/des.c.o
[ 53%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/polarssl/md4.c.o
[ 54%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/polarssl/md5.c.o
[ 55%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcore.dir/__/__/__/__/src/netif/ppp/polarssl/sha1.c.o
[ 55%] Linking C static library liblwipcore.a
[ 55%] Built target lwipcore
[ 56%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_asn1.c.o
[ 57%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_core.c.o
[ 57%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_mib2.c.o
[ 58%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_mib2_icmp.c.o
[ 58%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_mib2_interfaces.c.o
[ 59%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_mib2_ip.c.o
[ 60%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_mib2_snmp.c.o
[ 60%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_mib2_system.c.o
[ 61%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_mib2_tcp.c.o
[ 61%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_mib2_udp.c.o
[ 62%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_snmpv2_framework.c.o
[ 63%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_snmpv2_usm.c.o
[ 63%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_msg.c.o
[ 64%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmpv3.c.o
[ 64%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_netconn.c.o
[ 65%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_pbuf_stream.c.o
[ 66%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_raw.c.o
[ 66%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_scalar.c.o
[ 67%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_table.c.o
[ 67%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_threadsync.c.o
[ 68%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/snmp/snmp_traps.c.o
[ 69%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/http/altcp_proxyconnect.c.o
[ 69%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/http/fs.c.o
[ 70%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/http/http_client.c.o
[ 70%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/http/httpd.c.o
[ 71%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/lwiperf/lwiperf.c.o
[ 72%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/smtp/smtp.c.o
[ 72%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/sntp/sntp.c.o
[ 73%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/mdns/mdns.c.o
[ 74%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/mdns/mdns_out.c.o
[ 74%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/mdns/mdns_domain.c.o
[ 75%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/netbiosns/netbiosns.c.o
[ 75%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/tftp/tftp.c.o
[ 76%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipallapps.dir/__/__/__/__/src/apps/mqtt/mqtt.c.o
[ 77%] Linking C static library liblwipallapps.a
[ 77%] Built target lwipallapps
[ 77%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipmbedtls.dir/__/__/__/__/src/apps/altcp_tls/altcp_tls_mbedtls.c.o
[ 78%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipmbedtls.dir/__/__/__/__/src/apps/altcp_tls/altcp_tls_mbedtls_mem.c.o
[ 79%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipmbedtls.dir/__/__/__/__/src/apps/snmp/snmpv3_mbedtls.c.o
[ 79%] Linking C static library liblwipmbedtls.a
warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: archive library: liblwipmbedtls.a the table of contents is empty (no object file members in the library define global symbols)
[ 79%] Built target lwipmbedtls
[ 79%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribexamples.dir/__/__/__/examples/httpd/fs_example/fs_example.c.o
[ 80%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribexamples.dir/__/__/__/examples/httpd/https_example/https_example.c.o
[ 80%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribexamples.dir/__/__/__/examples/httpd/ssi_example/ssi_example.c.o
[ 81%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribexamples.dir/__/__/__/examples/lwiperf/lwiperf_example.c.o
[ 82%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribexamples.dir/__/__/__/examples/mdns/mdns_example.c.o
[ 82%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribexamples.dir/__/__/__/examples/mqtt/mqtt_example.c.o
[ 83%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribexamples.dir/__/__/__/examples/ppp/pppos_example.c.o
[ 83%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribexamples.dir/__/__/__/examples/snmp/snmp_private_mib/lwip_prvmib.c.o
[ 84%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribexamples.dir/__/__/__/examples/snmp/snmp_v3/snmpv3_dummy.c.o
[ 85%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribexamples.dir/__/__/__/examples/snmp/snmp_example.c.o
[ 85%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribexamples.dir/__/__/__/examples/sntp/sntp_example.c.o
[ 86%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribexamples.dir/__/__/__/examples/tftp/tftp_example.c.o
[ 87%] Linking C static library liblwipcontribexamples.a
[ 87%] Built target lwipcontribexamples
[ 88%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribapps.dir/__/__/__/apps/httpserver/httpserver-netconn.c.o
[ 89%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribapps.dir/__/__/__/apps/chargen/chargen.c.o
[ 89%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribapps.dir/__/__/__/apps/udpecho/udpecho.c.o
[ 90%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribapps.dir/__/__/__/apps/tcpecho/tcpecho.c.o
[ 90%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribapps.dir/__/__/__/apps/shell/shell.c.o
[ 91%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribapps.dir/__/__/__/apps/udpecho_raw/udpecho_raw.c.o
[ 92%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribapps.dir/__/__/__/apps/tcpecho_raw/tcpecho_raw.c.o
[ 92%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribapps.dir/__/__/__/apps/netio/netio.c.o
[ 93%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribapps.dir/__/__/__/apps/ping/ping.c.o
[ 93%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribapps.dir/__/__/__/apps/socket_examples/socket_examples.c.o
[ 94%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribapps.dir/__/__/__/apps/rtp/rtp.c.o
[ 95%] Linking C static library liblwipcontribapps.a
[ 95%] Built target lwipcontribapps
[ 95%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribaddons.dir/__/__/__/addons/tcp_isn/tcp_isn.c.o
[ 96%] Building C object contrib/ports/unix/example_app/CMakeFiles/lwipcontribaddons.dir/__/__/__/addons/ipv6_static_routing/ip6_route_table.c.o
[ 96%] Linking C static library liblwipcontribaddons.a
[ 96%] Built target lwipcontribaddons
[ 96%] Building C object contrib/ports/unix/example_app/CMakeFiles/example_app.dir/__/__/__/examples/example_app/test.c.o
[ 97%] Building C object contrib/ports/unix/example_app/CMakeFiles/example_app.dir/default_netif.c.o
[ 97%] Linking C executable example_app
[ 97%] Built target example_app
[ 98%] Building C object contrib/ports/unix/example_app/CMakeFiles/makefsdata.dir/__/__/__/__/src/apps/http/makefsdata/makefsdata.c.o
[100%] Linking C executable makefsdata
[100%] Built target makefsdata
```

</details> 
